### PR TITLE
Warn users about permissions required by open seadragon

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,8 +12,8 @@ issue.
 
 For Apache, with Drupal running on the same box as Apache, a couple lines like:
 
-ProxyPass /adore-djatoka/ http://localhost:8080/adore-djatoka/
-ProxyPassReverse /adore-djatoka/ http://localhost:8080/adore-djatoka/
+ProxyPass /adore-djatoka http://localhost:8080/adore-djatoka
+ProxyPassReverse /adore-djatoka http://localhost:8080/adore-djatoka
 
 in the Apache config somewhere (either the main apache.conf, httpd.conf, or in
 and arbitrarily named *.conf in your Apache's conf.d directory should suffice 

--- a/islandora_openseadragon.install
+++ b/islandora_openseadragon.install
@@ -37,3 +37,10 @@ function islandora_openseadragon_uninstall() {
   );
   array_walk($variables, 'variable_del');
 }
+
+function islandora_openseadragon_enable() {
+  if(!user_access(FEDORA_VIEW_OBJECTS, user_load(0))) {
+    drupal_set_message(t('Open Seadragon viewer requires that the annoymous user has this permission
+      "View repository objects and datastreams" enabled. ' . l('Permissions', 'admin/people/permissions')), 'warning');
+  }
+}

--- a/islandora_openseadragon.install
+++ b/islandora_openseadragon.install
@@ -39,8 +39,8 @@ function islandora_openseadragon_uninstall() {
 }
 
 function islandora_openseadragon_enable() {
-  if(!user_access(FEDORA_VIEW_OBJECTS, user_load(0))) {
+  if (!user_access(FEDORA_VIEW_OBJECTS, user_load(0))) {
     drupal_set_message(t('Open Seadragon viewer requires that the annoymous user has this permission
-      "View repository objects and datastreams" enabled. ' . l('Permissions', 'admin/people/permissions')), 'warning');
+      "View repository objects and datastreams" enabled.') . ' ' . l(t('Permissions'), 'admin/people/permissions'), 'warning');
   }
 }

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -69,6 +69,11 @@ function islandora_openseadragon_callback($uri = NULL) {
  * Implements hook_preprocess().
  */
 function islandora_openseadragon_preprocess_islandora_openseadragon_viewer(&$variables) {
+  if(!user_access(FEDORA_VIEW_OBJECTS, user_load(0))) {
+    drupal_set_message(t('Open Seadragon viewer requires that the annoymous user has this permission
+      "View repository objects and datastreams" enabled. ' . l('Permissions', 'admin/people/permissions')), 'warning');
+  }
+
   $library_path = libraries_get_path('openseadragon');
   $module_path = drupal_get_path('module', 'islandora_openseadragon');
   $variables['viewer_id'] = 'islandora-openseadragon';

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -69,9 +69,9 @@ function islandora_openseadragon_callback($uri = NULL) {
  * Implements hook_preprocess().
  */
 function islandora_openseadragon_preprocess_islandora_openseadragon_viewer(&$variables) {
-  if(!user_access(FEDORA_VIEW_OBJECTS, user_load(0))) {
+  if (!user_access(FEDORA_VIEW_OBJECTS, user_load(0))) {
     drupal_set_message(t('Open Seadragon viewer requires that the annoymous user has this permission
-      "View repository objects and datastreams" enabled. ' . l('Permissions', 'admin/people/permissions')), 'warning');
+      "View repository objects and datastreams" enabled.') . ' ' . l(t('Permissions'), 'admin/people/permissions'), 'warning');
   }
 
   $library_path = libraries_get_path('openseadragon');


### PR DESCRIPTION
Warn users about permissions required by open seadragon. This is using the new permissions in https://github.com/Islandora/islandora/pull/231
