### PR TITLE
Address some version compatibility issues with the OpenSeadragon library.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -40,7 +40,7 @@ DEPENDENCIES
 We assume the core OpenSeadragon Javascript is put into sites/all/libraries/openseadragon. 
 The most current version breaks the Islandora integration, which will be addressed in the 
 future. The correct version for Islandora can be obtained from here:
-https://github.com/thatcher/openseadragon/tarball/1c7f5839f90c28e97c96c169fdf23da24826605f
+http://openseadragon.github.com/openseadragon.zip
 * There is a conditional dependency on the islandora_paged_content module, but should not require
 any additional actions from the user as the solution packs that use the feature requiring the 
 islandora_paged_content module include it in their depency lists.

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Extract the version from the Javascript file.
+ *
+ * @return int
+ *   An integer as provided by islandora_openseadragon_version_string_to_int().
+ *
+ * @see islandora_openseadragon_version_string_to_int()
+ */
+function islandora_openseadragon_get_installed_version() {
+   $version = &drupal_static(__FUNCTION__, NULL);
+
+   if ($version === NULL) {
+     $path = libraries_get_path('openseadragon');
+     $openseadragon_js = file_get_contents("$path/openseadragon.js");
+     $matches = array();
+     $count = preg_match('/@version\s+OpenSeadragon\s+((\d+\.){2}\d+)/', $openseadragon_js, $matches);
+     if ($count) {
+       $version = islandora_openseadragon_version_string_to_int($matches[1]);
+     }
+   }
+
+   return $version;
+}
+
+/**
+ * Parse the version to something more comparable.
+ *
+ * Versions seem to go to three digits, in each component...  Build something
+ * up...
+ *
+ * @param string $version_string
+ *   A version string as OpenSeadragon (currently) uses in the JS doxygen
+ *   comments...  Something like: "0.9.124" or "0.9.76".
+ *
+ * @return int
+ *   An integer representing the version.
+ */
+function islandora_openseadragon_version_string_to_int($version_string) {
+   $version = 0;
+   foreach (explode('.', $version_string) as $part) {
+     $version *= 1000;
+     $version += intval($part);
+   }
+   return $version;
+}

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -74,14 +74,43 @@ function islandora_openseadragon_callback($params = NULL, $fedora_object = NULL)
  * Implements hook_preprocess().
  */
 function islandora_openseadragon_preprocess_islandora_openseadragon_viewer(&$variables) {
+  global $base_url;
+
   // Variable fedora_object included in results, but not used.
   $library_path = libraries_get_path('openseadragon');
   $module_path = drupal_get_path('module', 'islandora_openseadragon');
   $variables['viewer_id'] = 'islandora-openseadragon';
   $settings = array(
     'id' => $variables['viewer_id'],
-    'prefixUrl' => url($library_path),
+    // XXX: Can't use url(), as it can add in language prefixes, which will break
+    // the URL.
+    'prefixUrl' => "$base_url/$library_path/images/",
   );
+
+  module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');
+  $installed_version = islandora_openseadragon_get_installed_version();
+
+  if ($installed_version <= islandora_openseadragon_version_string_to_int('0.9.82')) {
+    // XXX: Version numbers don't quite line-up for the change in the nav image
+    // prefix URL, so now, let the hacking begin!... Just for compatibility
+    // with older versions.
+    $types = array('zoomIn', 'zoomOut', 'home', 'fullpage', 'previous', 'next');
+    $actions = array(
+      'REST' => 'rest',
+      'GROUP' => 'grouphover',
+      'HOVER' => 'hover',
+      'DOWN' => 'pressed'
+    );
+    foreach ($types as $type) {
+      foreach ($actions as $action => $namepart) {
+        $settings['navImages'][$type][$action] = format_string('!type_!action.png', array(
+          '!type' => strtolower($type),
+          '!action' => $namepart,
+        ));
+      }
+    }
+  }
+
   $settings = array_merge($settings, islandora_openseadragon_get_settings());
   foreach ($settings as $key => $val) {
     if (filter_var($val, FILTER_VALIDATE_FLOAT)) {

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -74,17 +74,13 @@ function islandora_openseadragon_callback($params = NULL, $fedora_object = NULL)
  * Implements hook_preprocess().
  */
 function islandora_openseadragon_preprocess_islandora_openseadragon_viewer(&$variables) {
-  global $base_url;
-
   // Variable fedora_object included in results, but not used.
   $library_path = libraries_get_path('openseadragon');
   $module_path = drupal_get_path('module', 'islandora_openseadragon');
   $variables['viewer_id'] = 'islandora-openseadragon';
   $settings = array(
     'id' => $variables['viewer_id'],
-    // XXX: Can't use url(), as it can add in language prefixes, which will break
-    // the URL.
-    'prefixUrl' => "$base_url/$library_path/images/",
+    'prefixUrl' => file_create_url("$library_path/images/"),
   );
 
   module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');


### PR DESCRIPTION
Older versions build the paths to the navigation button images (zoom/home/fullscreen buttons) differently, and version numbers do not suffice to differentiate how to provide the "prefixUrl"... Instead, we override all the image URLs with how the current code provides them.

Addresses OnTime 904.
