### PR TITLE
Enable Djatoka server base URL to be configurable

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -26,6 +26,14 @@ function islandora_openseadragon_admin($form, &$form_state) {
     '#default_value' => $settings['debugMode'],
     '#description' => t('Toggles whether messages should be logged and fail-fast behavior should be provided.'),
   );
+  // Location of the djatoka servers.
+  $form['islandora_openseadragon_settings']['djatokaServerBaseURL'] = array(
+  		'#type' => 'textfield',
+  		'#title' => t('Djatoka server base URL'),
+  		'#element_validate' => array('djatoka_base_url_validate'),
+  		'#default_value' => $settings['djatokaServerBaseURL'],
+  		'#description' => t('The location of the Djatoka server OpenURL resolver.'),
+  );
   // Animation time.
   $form['islandora_openseadragon_settings']['animationTime'] = array(
     '#type' => 'textfield',
@@ -234,6 +242,27 @@ function islandora_openseadragon_admin($form, &$form_state) {
   );
 
   return system_settings_form($form);
+}
+
+function djatoka_base_url_validate($element, &$form_state, $form) {
+  $url = $element['#value'];
+
+  if (empty($url)) {
+    form_error($element, t('This field is required.'));
+  }
+  else {
+  	// Work around drupal_http_request's not handling relative URLs
+    if (strpos($url, '/') === 0) {
+      $url = $GLOBALS['base_url'] . $url;
+    }
+
+    // Check that it's working with LOC's stable external JP2 image
+    $result = drupal_http_request(check_url($url) . '?url_ver=Z39.88-2004&rft_id=http%3A%2F%2Fmemory.loc.gov%2Fgmd%2Fgmd433%2Fg4330%2Fg4330%2Fnp000066.jp2&svc_id=info:lanl-repo/svc/getRegion&svc_val_fmt=info:ofi/fmt:kev:mtx:jpeg2000&svc.format=image/jpeg&svc.level=1');
+
+    if ($result->code != 200) {
+      form_error($element, t('This does not seem to be a functioning Djatoka server.'));
+    }
+  }
 }
 
 /**

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -259,7 +259,7 @@ function djatoka_base_url_validate($element, &$form_state, $form) {
       $url = $GLOBALS['base_url'] . $url;
     }
 
-    // Check that it's working with LOC's stable external JP2 image
+    // Check that it's working with LOC's stable external JP2 image.
     $result = drupal_http_request(check_url($url) . '?url_ver=Z39.88-2004&rft_id=http%3A%2F%2Fmemory.loc.gov%2Fgmd%2Fgmd433%2Fg4330%2Fg4330%2Fnp000066.jp2&svc_id=info:lanl-repo/svc/getRegion&svc_val_fmt=info:ofi/fmt:kev:mtx:jpeg2000&svc.format=image/jpeg&svc.level=1');
 
     if ($result->code != 200) {

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -28,11 +28,11 @@ function islandora_openseadragon_admin($form, &$form_state) {
   );
   // Location of the djatoka servers.
   $form['islandora_openseadragon_settings']['djatokaServerBaseURL'] = array(
-  		'#type' => 'textfield',
-  		'#title' => t('Djatoka server base URL'),
-  		'#element_validate' => array('djatoka_base_url_validate'),
-  		'#default_value' => $settings['djatokaServerBaseURL'],
-  		'#description' => t('The location of the Djatoka server OpenURL resolver.'),
+    '#type' => 'textfield',
+    '#title' => t('Djatoka server base URL'),
+    '#element_validate' => array('djatoka_base_url_validate'),
+    '#default_value' => $settings['djatokaServerBaseURL'],
+    '#description' => t('The location of the Djatoka server OpenURL resolver.'),
   );
   // Animation time.
   $form['islandora_openseadragon_settings']['animationTime'] = array(
@@ -244,6 +244,9 @@ function islandora_openseadragon_admin($form, &$form_state) {
   return system_settings_form($form);
 }
 
+/**
+ * Validates that the supplied djatoka base URL is a working djatoka install.
+ */
 function djatoka_base_url_validate($element, &$form_state, $form) {
   $url = $element['#value'];
 
@@ -251,7 +254,7 @@ function djatoka_base_url_validate($element, &$form_state, $form) {
     form_error($element, t('This field is required.'));
   }
   else {
-  	// Work around drupal_http_request's not handling relative URLs
+    // Work around drupal_http_request's not handling relative URLs.
     if (strpos($url, '/') === 0) {
       $url = $GLOBALS['base_url'] . $url;
     }

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -117,6 +117,9 @@ function islandora_openseadragon_preprocess_islandora_openseadragon_viewer(&$var
     elseif (filter_var($val, FILTER_VALIDATE_INT)) {
       $settings[$key] = (int) $val;
     }
+    elseif (filter_var($val, FILTER_VALIDATE_URL)) {
+      $settings[$key] = $val;
+    }
   }
 
   // This is where we jam in some HOCR coordinates.
@@ -171,6 +174,7 @@ function islandora_openseadragon_preprocess_islandora_openseadragon_viewer(&$var
 function islandora_openseadragon_get_settings() {
   return variable_get('islandora_openseadragon_settings', array(
       'debugMode' => FALSE,
+      'djatokaServerBaseURL' => '/adore-djatoka/resolver',
       'animationTime' => '1.5',
       'blendTime' => '0.1',
       'alwaysBlend' => FALSE,

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -118,7 +118,7 @@ function islandora_openseadragon_preprocess_islandora_openseadragon_viewer(&$var
       $settings[$key] = (int) $val;
     }
     elseif (filter_var($val, FILTER_VALIDATE_URL)) {
-      $settings[$key] = $val;
+      $settings[$key] = check_url($val);
     }
   }
 

--- a/js/djtilesource.js
+++ b/js/djtilesource.js
@@ -9,17 +9,19 @@
    *
    * @class
    * @extends Seadragon.TileSource
+   * @param {string} baseURL
+   *   The base URL of the djatoka server.
    * @param {string} imageID
-   *   The UR{I,L} of the image.
+   *   The image identifier.
    */
-  $.DjatokaTileSource = function(imageID, settings) {
+  $.DjatokaTileSource = function(baseURL, imageID, settings) {
     var that = this;
     var djatoka_get_params = {
       'url_ver': 'Z39.88-2004',
       'rft_id': imageID,
       'svc_id': 'info:lanl-repo/svc/getMetadata'
     };
-    this.baseURL = '/adore-djatoka/resolver';
+    this.baseURL = baseURL;
     this.imageID = imageID;
     var djatoka_get_success = function(data, textStatus, jqXHR) {
       $.TileSource.call(

--- a/js/islandora_openseadragon.js
+++ b/js/islandora_openseadragon.js
@@ -9,7 +9,7 @@
           config.tileSources = new Array();
           resourceUri = (resourceUri instanceof Array) ? resourceUri : new Array(resourceUri);
           $.each(resourceUri, function(index, uri) {
-            var tileSource = new OpenSeadragon.DjatokaTileSource(uri, settings.islandoraOpenSeadragon);
+            var tileSource = new OpenSeadragon.DjatokaTileSource(config.djatokaServerBaseURL, uri, settings.islandoraOpenSeadragon);
             config.tileSources.push(tileSource);
           });
           var viewer = new OpenSeadragon(config);


### PR DESCRIPTION
Allows the djatoka server's base url to be configurable and also performs a check to make sure what's input for this value in the admin config actually interacts with a functioning djatoka server.
