### PR TITLE
Windows-compatibility: Backslashes in paths (OpenSeadragon: 7.x-1.3)

### DIFF
--- a/js/djtilesource.js
+++ b/js/djtilesource.js
@@ -24,7 +24,7 @@
     this.baseURL = baseURL;
     this.imageID = imageID;
     var djatoka_get_success = function(data, textStatus, jqXHR) {
-      // Determine if the path to "imagefile" has backslashes in it.
+      // Determine if the path to 'imagefile' has backslashes in it.
       if (data.match(/\"imagefile\"\: \"[^\"]*?(\\).*\"/g)) {
         // Since Djatoka isn't returning a true JSON object (http://bit.ly/1id6dBo),
         // backslashes in the JP2 file path (Windows) are getting mistaken for escaped

--- a/js/djtilesource.js
+++ b/js/djtilesource.js
@@ -24,6 +24,16 @@
     this.baseURL = baseURL;
     this.imageID = imageID;
     var djatoka_get_success = function(data, textStatus, jqXHR) {
+      // Determine if the path to "imagefile" has backslashes in it.
+      if (data.match(/\"imagefile\"\: \"[^\"]*?(\\).*\"/g)) {
+        // Since Djatoka isn't returning a true JSON object (http://bit.ly/1id6dBo),
+        // backslashes in the JP2 file path (Windows) are getting mistaken for escaped
+        // characters. Escape the backslashes themselves so the viewer doesn't break.
+        data = data.replace(/(\"imagefile\"\: \")(.*?)(\")/g, function (match, capture1, imagepath, capture3) {
+          return capture1 + imagepath.replace(/\\/g, '\\\\') + capture3
+        });
+      }
+      data = jQuery.parseJSON(data);
       $.TileSource.call(
 	that,
 	parseInt(data.width),
@@ -38,7 +48,7 @@
       that.getTileUrl = $.DjatokaTileSource.prototype.getTileUrl;
     };
     jQuery.ajaxSetup({async: false});
-    jQuery.get(this.baseURL, djatoka_get_params, djatoka_get_success, 'json');
+    jQuery.get(this.baseURL, djatoka_get_params, djatoka_get_success, 'text');
     jQuery.ajaxSetup({async:true});
   };
   jQuery.extend($.DjatokaTileSource.prototype, $.TileSource.prototype); // Inherit from TileSource.

--- a/js/djtilesource.js
+++ b/js/djtilesource.js
@@ -24,7 +24,7 @@
     this.baseURL = baseURL;
     this.imageID = imageID;
     var djatoka_get_success = function(data, textStatus, jqXHR) {
-      // Determine if the path to 'imagefile' has backslashes in it.
+      // Determine if the path to "imagefile" has backslashes in it.
       if (data.match(/\"imagefile\"\: \"[^\"]*?(\\).*\"/g)) {
         // Since Djatoka isn't returning a true JSON object (http://bit.ly/1id6dBo),
         // backslashes in the JP2 file path (Windows) are getting mistaken for escaped


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).

When the page first loads, the OpenSeadragon viewer caches the JP2 file in the tomcat temp directory. However, since [Djatoka is returning bad JSON](http://bit.ly/1id6dBo), any backslashes in the file path (found in Windows environments) end up getting misinterpreted by jQuery. As a result, the JP2 image never loads inside of the viewer. This patch escapes any existing backslashes in the "imagefile" element (returned by Djatoka) and fixes the problem.
