### PR TITLE
Fixes for drush command handling of paths.

### DIFF
--- a/islandora_openseadragon.drush.inc
+++ b/islandora_openseadragon.drush.inc
@@ -11,6 +11,12 @@
 define('OPENSEADRAGON_DOWNLOAD_URI', 'http://openseadragon.github.io/releases/openseadragon-bin-0.9.129.zip');
 
 /**
+ * The original OpenSeadragon directory
+ */
+define('OPENSEADRAGON_ORIGINAL_DIR', 'openseadragon-bin-0.9.129');
+
+
+/**
  * Implements hook_drush_command().
  */
 function islandora_openseadragon_drush_command() {
@@ -64,8 +70,7 @@ function drush_islandora_openseadragon_plugin() {
   // Download the zip archive.
   if ($filepath = drush_download_file(OPENSEADRAGON_DOWNLOAD_URI)) {
     $filename = basename($filepath);
-    // This assumes that the extracted directory is the same name as the zip file.
-    $dirname = substr($filename, 0, strrpos($filename, '.'));
+    $dirname = OPENSEADRAGON_ORIGINAL_DIR;
 
     // Remove any existing Openseadragon plugin directory.
     if (is_dir($dirname) || is_dir('openseadragon')) {

--- a/islandora_openseadragon.drush.inc
+++ b/islandora_openseadragon.drush.inc
@@ -48,7 +48,7 @@ function drush_islandora_openseadragon_plugin() {
     $path = $args[0];
   }
   else {
-    $path = 'sites/all/libraries';
+    $path = _drush_core_directory("@site:sites/all/libraries");
   }
 
   // Create the path if it does not exist.
@@ -64,7 +64,8 @@ function drush_islandora_openseadragon_plugin() {
   // Download the zip archive.
   if ($filepath = drush_download_file(OPENSEADRAGON_DOWNLOAD_URI)) {
     $filename = basename($filepath);
-    $dirname = 'openseadragon';
+    // This assumes that the extracted directory is the same name as the zip file.
+    $dirname = substr($filename, 0, strrpos($filename, '.'));
 
     // Remove any existing Openseadragon plugin directory.
     if (is_dir($dirname) || is_dir('openseadragon')) {


### PR DESCRIPTION
Plugin was not installing the library to the correct path or able to complete properly due to incorrect paths. 

Related to [ISLANDORA-1213](https://jira.duraspace.org/browse/ISLANDORA-1213)
