### PR TITLE
Fixes for drush commands handling of paths. (Release see #47)

### DIFF
--- a/islandora_openseadragon.drush.inc
+++ b/islandora_openseadragon.drush.inc
@@ -11,6 +11,11 @@
 define('OPENSEADRAGON_DOWNLOAD_URI', 'http://openseadragon.github.io/releases/openseadragon-bin-0.9.129.zip');
 
 /**
+ * The original OpenSeadragon directory
+ */
+define('OPENSEADRAGON_ORIGINAL_DIR', 'openseadragon-bin-0.9.129');
+
+/**
  * Implements hook_drush_command().
  */
 function islandora_openseadragon_drush_command() {
@@ -64,7 +69,7 @@ function drush_islandora_openseadragon_plugin() {
   // Download the zip archive.
   if ($filepath = drush_download_file(OPENSEADRAGON_DOWNLOAD_URI)) {
     $filename = basename($filepath);
-    $dirname = substr($filename, 0, strrpos($filename, '.'));
+    $dirname = OPENSEADRAGON_ORIGINAL_DIR;
 
     // Remove any existing Openseadragon plugin directory.
     if (is_dir($dirname) || is_dir('openseadragon')) {

--- a/islandora_openseadragon.drush.inc
+++ b/islandora_openseadragon.drush.inc
@@ -48,7 +48,7 @@ function drush_islandora_openseadragon_plugin() {
     $path = $args[0];
   }
   else {
-    $path = 'sites/all/libraries';
+    $path = _drush_core_directory("@site:sites/all/libraries");
   }
 
   // Create the path if it does not exist.
@@ -64,7 +64,7 @@ function drush_islandora_openseadragon_plugin() {
   // Download the zip archive.
   if ($filepath = drush_download_file(OPENSEADRAGON_DOWNLOAD_URI)) {
     $filename = basename($filepath);
-    $dirname = 'openseadragon';
+    $dirname = substr($filename, 0, strrpos($filename, '.'));
 
     // Remove any existing Openseadragon plugin directory.
     if (is_dir($dirname) || is_dir('openseadragon')) {


### PR DESCRIPTION
Plugin was not installing the library to the correct path or able to complete properly due to incorrect paths. 

Related to [ISLANDORA-1213](https://jira.duraspace.org/browse/ISLANDORA-1213)

Release branch PR of #47 
