### PR TITLE
Refactor clipping.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -69,7 +69,8 @@ function islandora_openseadragon_construct_clip_url($params, $download = FALSE) 
   // Replace the first left-most slash to get a more Drupal-y path to validate
   // against.
   $drupal_path = preg_replace('/\//', '', $path, 1);
-  if (!menu_get_item($drupal_path)) {
+  $item = menu_get_item($drupal_path);
+  if (!$item || $item['path'] !== 'islandora/object/%/datastream/%/view') {
     return FALSE;
   }
   $djatoka_url_params = drupal_http_build_query($djatoka_params + $allowed_djatoka_params);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -64,6 +64,14 @@ function islandora_openseadragon_construct_clip_url($params, $download = FALSE) 
   if (empty($allowed_djatoka_params)) {
     return FALSE;
   }
+  $rft_id = $decoded_params['rft_id'];
+  $path = parse_url($rft_id, PHP_URL_PATH);
+  // Replace the first left-most slash to get a more Drupal-y path to validate
+  // against.
+  $drupal_path = preg_replace('/\//', '', $path, 1);
+  if (!menu_get_item($drupal_path)) {
+    return FALSE;
+  }
   $djatoka_url_params = drupal_http_build_query($djatoka_params + $allowed_djatoka_params);
   // XXX: See if Djatoka is relative or absolute and handle accordingly.
   // Building up URL this way because may encounter a relative or absolute path

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -44,6 +44,7 @@ function islandora_openseadragon_get_installed_version() {
  *   Used when rendering the image on the print page.
  */
 function islandora_openseadragon_construct_clip_url($params, $download = FALSE) {
+  global $base_root;
   $settings = islandora_openseadragon_get_settings();
   $decoded_params = drupal_get_query_array($params);
   $djatoka_url = $settings['djatokaServerBaseURL'];
@@ -53,8 +54,8 @@ function islandora_openseadragon_construct_clip_url($params, $download = FALSE) 
     'svc_val_fmt' => 'info:ofi/fmt:kev:mtx:jpeg2000',
     'svc.format' => 'image/jpeg',
   );
-  // Only grab the three parameters that are expected to be there, ignore
-  // anything else.
+  // Only grab the two parameters that are expected to be there, ignore anything
+  // else.
   $allowed_djatoka_param_keys = drupal_map_assoc(array(
     'rft_id',
     'svc.region',
@@ -63,10 +64,19 @@ function islandora_openseadragon_construct_clip_url($params, $download = FALSE) 
   if (empty($allowed_djatoka_params)) {
     return FALSE;
   }
-  $url = url($djatoka_url, array(
-    'query' => $djatoka_params + $allowed_djatoka_params,
-    'absolute' => $download,
-  ));
+  $djatoka_url_params = drupal_http_build_query($djatoka_params + $allowed_djatoka_params);
+  // XXX: See if Djatoka is relative or absolute and handle accordingly.
+  // Building up URL this way because may encounter a relative or absolute path
+  // to Djatoka. Similarly, the built in Drupal functions such as URL will
+  // construct URLs with the multi-site/language prefixs present. Lastly, not
+  // using url_is_external as a relative Djatoka path may have two slashes
+  // preceding it which it would flag falsely.
+  if (!$download || strpos($djatoka_url, 'http') === 0) {
+    $url = "$djatoka_url?$djatoka_url_params";
+  }
+  else {
+    $url = "{$base_root}{$djatoka_url}?$djatoka_url_params";
+  }
   $dimensions = array();
   if (isset($decoded_params['dimensions'])) {
     $dimensions = explode(',', $decoded_params['dimensions']);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -26,3 +26,60 @@ function islandora_openseadragon_get_installed_version() {
 
   return $version;
 }
+
+/**
+ * Helper to construct the URL used to retrieve a "clip" from Djatoka.
+ *
+ * @param string $params
+ *   A string containing the $_GET clip value to be parsed.
+ * @param bool $download
+ *   Whether the URL being generated is for a download link.
+ *
+ * @return bool|array
+ *   FALSE when invalid parameters passed in, otherwise an array containing:
+ *   -original_params (string): A rawurlencoded string which can be used as or
+ *   appended to the URL query string.
+ *   -djatoka_image_url (string): URL to retrieve the image from Djatoka.
+ *   -dimensions (array): An array containing the width and height of the image.
+ *   Used when rendering the image on the print page.
+ */
+function islandora_openseadragon_construct_clip_url($params, $download = FALSE) {
+  $settings = islandora_openseadragon_get_settings();
+  $decoded_params = drupal_get_query_array($params);
+  $djatoka_url = $settings['djatokaServerBaseURL'];
+  $djatoka_params = array(
+    'url_ver' => 'Z39.88-2004',
+    'svc_id' => 'info:lanl-repo/svc/getRegion',
+    'svc_val_fmt' => 'info:ofi/fmt:kev:mtx:jpeg2000',
+    'svc.format' => 'image/jpeg',
+  );
+  // Only grab the three parameters that are expected to be there, ignore
+  // anything else.
+  $allowed_djatoka_param_keys = drupal_map_assoc(array(
+    'rft_id',
+    'svc.region',
+  ));
+  $allowed_djatoka_params = array_intersect_key($decoded_params, $allowed_djatoka_param_keys);
+  if (empty($allowed_djatoka_params)) {
+    return FALSE;
+  }
+  $url = url($djatoka_url, array(
+    'query' => $djatoka_params + $allowed_djatoka_params,
+    'absolute' => $download,
+  ));
+  $dimensions = array();
+  if (isset($decoded_params['dimensions'])) {
+    $dimensions = explode(',', $decoded_params['dimensions']);
+    $dimensions = array(
+      'width' => $dimensions[0],
+      'height' => $dimensions[1],
+    );
+  }
+  return array(
+    // XXX: Using drupal_http_build_query to avoid changing the underlying
+    // functionality in the solution packs that currently implement.
+    'original_params' => drupal_http_build_query($allowed_djatoka_params),
+    'djatoka_image_url' => $url,
+    'dimensions' => $dimensions,
+  );
+}

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -19,6 +19,14 @@ function islandora_openseadragon_menu() {
       'file' => 'includes/admin.form.inc',
       'type' => MENU_NORMAL_ITEM,
     ),
+    'islandora/object/%islandora_object/download_clip' => array(
+      'page callback' => 'islandora_openseadragon_download_clip',
+      'page arguments' => array(2),
+      'type' => MENU_CALLBACK,
+      'access callback' => 'islandora_object_access',
+      'access arguments' => array(ISLANDORA_VIEW_OBJECTS, 2),
+      'load arguments' => array(2),
+    ),
   );
 }
 
@@ -216,26 +224,25 @@ function islandora_openseadragon_get_settings() {
  * Implements hook_process_theme().
  */
 function islandora_openseadragon_preprocess_islandora_object_print(array &$variables) {
-  $object = $variables['object'];
   if (isset($_GET['clip'])) {
-    $dimensions = array();
-    if (isset($_GET['dimensions'])) {
-      $dimensions = explode(',', $_GET['dimensions']);
-      $dimensions = array(
-        'width' => $dimensions[0],
-        'height' => $dimensions[1],
+    module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');
+    $clip_parts = islandora_openseadragon_construct_clip_url($_GET['clip']);
+    if ($clip_parts) {
+      $variables['clip'] = $clip_parts['original_params'];
+      $variables['content']['clip'] = array(
+        '#weight' => 0,
+        '#prefix' => "<div id='clip'>",
+        '#markup' => theme_image(array(
+                     'path' => $clip_parts['djatoka_image_url'], 'attributes' => $clip_parts['dimensions'])),
+        '#suffix' => '</div>',
       );
     }
-    $variables['clip'] = $clip = $_GET['clip'];
-    $variables['content']['clip'] = array(
-      '#weight' => 0,
-      '#prefix' => "<div id='clip'>",
-      '#markup' => theme_image(array(
-                   'path' => $_GET['clip'], 'attributes' => $dimensions)),
-      '#suffix' => '</div>',
-    );
+    else {
+      drupal_set_message(t('Invalid clip parameters passed.'), 'error');
+    }
   }
 }
+
 
 /**
  * Theme function to create a clipper link.
@@ -258,4 +265,37 @@ function theme_islandora_openseadragon_clipper(&$variables) {
       'html' => TRUE,
     )
   );
+}
+
+/**
+ * Menu callback downloads the given clip.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing an object within Fedora.
+ */
+function islandora_openseadragon_download_clip(AbstractObject $object) {
+  if (isset($_GET['clip'])) {
+    module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');
+    $clip_parts = islandora_openseadragon_construct_clip_url($_GET['clip'], TRUE);
+    if ($clip_parts) {
+      $filename = $object->label;
+      header("Content-Disposition: attachment; filename=\"{$filename}.jpg\"");
+      header("Content-type: image/jpeg");
+      header("Content-Transfer-Encoding: binary");
+      $ch = curl_init();
+      curl_setopt($ch, CURLOPT_BINARYTRANSFER, 1);
+      curl_setopt($ch, CURLOPT_HEADER, 0);
+      curl_setopt($ch, CURLOPT_URL, $clip_parts['djatoka_image_url']);
+      curl_exec($ch);
+      curl_close($ch);
+    }
+    else {
+      drupal_access_denied();
+      watchdog('islandora_openseadragon', 'Invalid parameters specified for downloading of a clip for @pid. Parameters attempted: @params.', array(
+        '@pid' => $object->id,
+        '@params' => $_GET['clip'],
+      ));
+    }
+  }
+  exit();
 }

--- a/js/islandora_openseadragon.js
+++ b/js/islandora_openseadragon.js
@@ -62,17 +62,12 @@
             var box = getDisplayRegion(viewer, new OpenSeadragon.Point(parseInt(source.dimensions.x*level), parseInt(source.dimensions.y*level)));
             var scaled_box = new OpenSeadragon.Rect(parseInt(box.x/level), parseInt(box.y/level), parseInt(box.width/level), parseInt(box.height/level));
             var params = {
-              'url_ver': 'Z39.88-2004',
-              'rft_id': source.imageID,
-              'svc_id': 'info:lanl-repo/svc/getRegion',
-              'svc_val_fmt': 'info:ofi/fmt:kev:mtx:jpeg2000',
-              'svc.format': 'image/jpeg',
-              'svc.region': scaled_box.y + ',' + scaled_box.x + ',' + (scaled_box.getBottomRight().y - scaled_box.y) + ',' + (scaled_box.getBottomRight().x - scaled_box.x),
+                'rft_id': source.imageID,
+                'svc.region': scaled_box.y + ',' + scaled_box.x + ',' + (scaled_box.getBottomRight().y - scaled_box.y) + ',' + (scaled_box.getBottomRight().x - scaled_box.x),
+                'dimensions': (zoom <= 1) ? source.dimensions.x + ',' + source.dimensions.y : container.x + ',' + container.y
             };
-            var dimensions = (zoom <= 1) ? source.dimensions.x + ',' + source.dimensions.y : container.x + ',' + container.y;
             jQuery("#clip").attr('href',  Drupal.settings.basePath + 'islandora/object/' + settings.islandoraOpenSeadragon.pid + '/print?' + jQuery.param({
-              'clip': source.baseURL + '?' + jQuery.param(params),
-              'dimensions': dimensions,
+              'clip': jQuery.param(params)
             }));
           };
           viewer.addHandler("open", update_clip);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1696
- Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
  https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/islandora-dev/8eSxcOtSlX4/pw_VAFZbAgAJ
# What does this Pull Request do?

Refactors clipping to pass parameters and not a fully crafted URL.
# What's new?
- Changes to what parameters are being passed through the 'clip' `$_GET parameter`. Previously a fully constructed URL was passed through representing the URL to Djatoka. Now only the `rft_id/svc.region` parameters for Djatoka will be set on the clip ID as well as the dimensions of the current image. Any other parameters passed through clip `$_GET` parameter will be ignored.
- The URL constructed will use the Djatoka URL configured through the admin page for the module. Note that I tested this with both a relative and absolute URL.
- Downloading a clip will only occur if the 'clip' `$_GET` parameter constitutes a valid URL otherwise will drupal_access_denied and watchdog if not. 
# Interested parties

@Islandora/7-x-1-x-committers
