### PR TITLE
ISLANDORA-1795: Fix "invalid clip parametters passed" error if base URL path is a sub dir

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -66,6 +66,10 @@ function islandora_openseadragon_construct_clip_url($params, $download = FALSE) 
   }
   $rft_id = $decoded_params['rft_id'];
   $path = parse_url($rft_id, PHP_URL_PATH);
+  // Remove sub dir from $path
+  if (base_path() !== '/') {
+    $path = substr($path, strlen(base_path()) - 1);
+  }
   // Replace the first left-most slash to get a more Drupal-y path to validate
   // against.
   $drupal_path = preg_replace('/\//', '', $path, 1);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -66,7 +66,7 @@ function islandora_openseadragon_construct_clip_url($params, $download = FALSE) 
   }
   $rft_id = $decoded_params['rft_id'];
   $path = parse_url($rft_id, PHP_URL_PATH);
-  // Remove sub dir from $path
+  // Remove sub dir from $path.
   if (base_path() !== '/') {
     $path = substr($path, strlen(base_path()) - 1);
   }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1795
- Other Relevant Links: https://groups.google.com/forum/#!topic/islandora/zUjC2xvWWEc 

Clipper functionality throws an "Invalid clip parameters passed"
error if the base URL path of your site is a sub directory.

This fix will remove the sub dir (if exists) before verifying path.
