### PR TITLE
Added new field which allows use to specify a JP2 to test djatoka with, either a PID of and object with a JP2 ds or the new test.jp2 in the newly created /tests directory. the field defaults to LOCs stable JP2.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -264,8 +264,18 @@ function islandora_openseadragon_admin($form, &$form_state) {
  */
 function djatoka_base_url_validate($element, &$form_state, $form) {
   $jp2_image = drupal_get_path('module', 'islandora_openseadragon') . '/test/test.jp2';
-  $image_url = url($jp2_image, array('absolute' => TRUE));
+  $image_url = file_create_url($jp2_image);
   $server_url = $element['#value'];
+  $dimensions = '0,0,100,100';
+  $request = array(
+    '?url_ver' => 'Z39.88-2004',
+    'rft_id' => $image_url,
+    'svc_id' => 'info:lanl-repo/svc/getRegion',
+    'svc_val_fmt' => 'info:ofi/fmt:kev:mtx:jpeg2000',
+    'svc.format' => 'image/jpeg',
+    'svc.region' => $dimensions,
+    'svc.level' => '1',
+  );
 
   if (empty($server_url)) {
     form_error($element, t('This field is required.'));
@@ -277,16 +287,22 @@ function djatoka_base_url_validate($element, &$form_state, $form) {
       $server_url = $GLOBALS['base_root'] . $server_url;
     }
 
-    $full_url = check_url($server_url) . '?url_ver=Z39.88-2004&rft_id=' . $image_url . '&svc_id=info:lanl-repo/svc/getRegion&svc_val_fmt=info:ofi/fmt:kev:mtx:jpeg2000&svc.format=image/jpeg&svc.level=1';
-    $result = drupal_http_request($full_url);
+    $full_url = $server_url . drupal_http_build_query($request);
+    $result = drupal_http_request(urldecode($full_url));
     $server = FALSE;
 
-    if ($result->code == 200) {
-      $image = getimagesize($full_url);
+    if ($result->code == 200 && $result->headers['content-type'] == 'image/jpeg') {
+      $file = file_save_data($result->data, 'temporary://temp.jpg');
+      $file->status &= FILE_STATUS_PERMANENT;
+      $info = file_save($file);
+      $info = image_get_info(drupal_realpath($file->uri));
+      $dimesnions_test = $info['width'] === 100 && $info['height'] === 100;
 
-      if (isset($image['mime']) && $image['mime'] == 'image/jpeg') {
+      if (isset($info['mime_type']) && $info['mime_type'] == 'image/jpeg' && $dimesnions_test) {
         $server = TRUE;
       }
+
+      file_delete($file);
     }
 
     if (!$server) {

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -34,6 +34,14 @@ function islandora_openseadragon_admin($form, &$form_state) {
     '#default_value' => $settings['djatokaServerBaseURL'],
     '#description' => t('The location of the Djatoka server OpenURL resolver.'),
   );
+  // Djatoka local file or PID test.
+  $form['islandora_openseadragon_settings']['djatokaJP2Image'] = array(
+    '#type' => 'textfield',
+    '#title' => t('JP2 Image Test'),
+    '#description' => t('Enter the PID of an object that has a JP2 datastream to test against Djatoka server. Defaults to LOC map image. Alternatively, you can use a local JP2 by entering this path: ' . drupal_get_path('module', 'islandora_openseadragon') . '/test/test.jp2'),
+    '#default_value' => (isset($settings['djatokaJP2Image']) ? $settings['djatokaJP2Image'] : ''),
+  );
+
   // Animation time.
   $form['islandora_openseadragon_settings']['animationTime'] = array(
     '#type' => 'textfield',
@@ -263,21 +271,54 @@ function islandora_openseadragon_admin($form, &$form_state) {
  * Validates that the supplied djatoka base URL is a working djatoka install.
  */
 function djatoka_base_url_validate($element, &$form_state, $form) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
   $url = $element['#value'];
+  $image_url = 'http://memory.loc.gov/gmd/gmd433/g4330/g4330/np000066.jp2';
+  $jp2_image = $form_state['values']['islandora_openseadragon_settings']['djatokaJP2Image'];
+
+  if (islandora_is_valid_pid($jp2_image)) {
+    $object = islandora_object_load($jp2_image);
+    
+    if ($object && isset($object['JP2'])) {
+      module_load_include('inc', 'islandora', 'includes/authtokens');
+      $token = islandora_get_object_token($object->id, 'JP2', 2);
+      $image_url = url("islandora/object/{$object->id}/datastream/JP2/view",
+        array(
+          'absolute' => TRUE,
+          'query' => array('token' => $token),
+        ));
+    }
+    else {
+      dsm('object does not have a valid jp2.');
+    }
+  }
+  elseif (!empty($jp2_image))  {
+    $image_url = url($jp2_image, array('absolute' => TRUE,));
+  }
 
   if (empty($url)) {
     form_error($element, t('This field is required.'));
   }
   else {
+
     // Work around drupal_http_request's not handling relative URLs.
     if (strpos($url, '/') === 0) {
-      $url = $GLOBALS['base_root'] . $url;
+      $url = $GLOBALS['base_root'] . ':8080'  . $url;
     }
 
-    // Check that it's working with LOC's stable external JP2 image.
-    $result = drupal_http_request(check_url($url) . '?url_ver=Z39.88-2004&rft_id=http%3A%2F%2Fmemory.loc.gov%2Fgmd%2Fgmd433%2Fg4330%2Fg4330%2Fnp000066.jp2&svc_id=info:lanl-repo/svc/getRegion&svc_val_fmt=info:ofi/fmt:kev:mtx:jpeg2000&svc.format=image/jpeg&svc.level=1');
-
-    if ($result->code != 200) {
+    $full_url = check_url($url) . '?url_ver=Z39.88-2004&rft_id=' . $image_url . '&svc_id=info:lanl-repo/svc/getRegion&svc_val_fmt=info:ofi/fmt:kev:mtx:jpeg2000&svc.format=image/jpeg&svc.level=1';
+    $result = drupal_http_request($full_url);
+    $server = FALSE;
+    
+    if ($result->code == 200) {
+      $image = getimagesize($full_url);
+      
+      if (isset($image['mime']) && $image['mime'] == 'image/jpeg') {
+        $server = TRUE;
+      }
+    }
+    
+    if (!$server) {
       form_error($element, t('This does not seem to be a functioning Djatoka server.'));
     }
   }
@@ -288,6 +329,7 @@ function djatoka_base_url_validate($element, &$form_state, $form) {
  */
 function islandora_openseadragon_admin_submit($form, &$form_state) {
   $op = $form_state['clicked_button']['#id'];
+  dpm($op);
   switch ($op) {
     case 'edit-reset':
       variable_del('islandora_openseadragon_settings');

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -284,7 +284,7 @@ function djatoka_base_url_validate($element, &$form_state, $form) {
 
     // Work around drupal_http_request's not handling relative URLs.
     if (strpos($server_url, '/') === 0) {
-      $server_url = $GLOBALS['base_root'] . ':8080' . $server_url;
+      $server_url = $GLOBALS['base_root'] . $server_url;
     }
 
     $full_url = $server_url . '?' . drupal_http_build_query($request);

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -34,14 +34,6 @@ function islandora_openseadragon_admin($form, &$form_state) {
     '#default_value' => $settings['djatokaServerBaseURL'],
     '#description' => t('The location of the Djatoka server OpenURL resolver.'),
   );
-  // Djatoka local file or PID test.
-  $form['islandora_openseadragon_settings']['djatokaJP2Image'] = array(
-    '#type' => 'textfield',
-    '#title' => t('JP2 Image Test'),
-    '#description' => t('Enter the PID of an object that has a JP2 datastream to test against Djatoka server. Defaults to LOC map image. Alternatively, you can use a local JP2 by entering this path: ' . drupal_get_path('module', 'islandora_openseadragon') . '/test/test.jp2'),
-    '#default_value' => (isset($settings['djatokaJP2Image']) ? $settings['djatokaJP2Image'] : ''),
-  );
-
   // Animation time.
   $form['islandora_openseadragon_settings']['animationTime'] = array(
     '#type' => 'textfield',
@@ -271,53 +263,32 @@ function islandora_openseadragon_admin($form, &$form_state) {
  * Validates that the supplied djatoka base URL is a working djatoka install.
  */
 function djatoka_base_url_validate($element, &$form_state, $form) {
-  module_load_include('inc', 'islandora', 'includes/utilities');
-  $url = $element['#value'];
-  $image_url = 'http://memory.loc.gov/gmd/gmd433/g4330/g4330/np000066.jp2';
-  $jp2_image = $form_state['values']['islandora_openseadragon_settings']['djatokaJP2Image'];
+  $jp2_image = drupal_get_path('module', 'islandora_openseadragon') . '/test/test.jp2';
+  $image_url = url($jp2_image, array('absolute' => TRUE));
+  $server_url = $element['#value'];
 
-  if (islandora_is_valid_pid($jp2_image)) {
-    $object = islandora_object_load($jp2_image);
-    
-    if ($object && isset($object['JP2'])) {
-      module_load_include('inc', 'islandora', 'includes/authtokens');
-      $token = islandora_get_object_token($object->id, 'JP2', 2);
-      $image_url = url("islandora/object/{$object->id}/datastream/JP2/view",
-        array(
-          'absolute' => TRUE,
-          'query' => array('token' => $token),
-        ));
-    }
-    else {
-      dsm('object does not have a valid jp2.');
-    }
-  }
-  elseif (!empty($jp2_image))  {
-    $image_url = url($jp2_image, array('absolute' => TRUE,));
-  }
-
-  if (empty($url)) {
+  if (empty($server_url)) {
     form_error($element, t('This field is required.'));
   }
   else {
 
     // Work around drupal_http_request's not handling relative URLs.
-    if (strpos($url, '/') === 0) {
-      $url = $GLOBALS['base_root'] . ':8080'  . $url;
+    if (strpos($server_url, '/') === 0) {
+      $server_url = $GLOBALS['base_root'] . $server_url;
     }
 
-    $full_url = check_url($url) . '?url_ver=Z39.88-2004&rft_id=' . $image_url . '&svc_id=info:lanl-repo/svc/getRegion&svc_val_fmt=info:ofi/fmt:kev:mtx:jpeg2000&svc.format=image/jpeg&svc.level=1';
+    $full_url = check_url($server_url) . '?url_ver=Z39.88-2004&rft_id=' . $image_url . '&svc_id=info:lanl-repo/svc/getRegion&svc_val_fmt=info:ofi/fmt:kev:mtx:jpeg2000&svc.format=image/jpeg&svc.level=1';
     $result = drupal_http_request($full_url);
     $server = FALSE;
-    
+
     if ($result->code == 200) {
       $image = getimagesize($full_url);
-      
+
       if (isset($image['mime']) && $image['mime'] == 'image/jpeg') {
         $server = TRUE;
       }
     }
-    
+
     if (!$server) {
       form_error($element, t('This does not seem to be a functioning Djatoka server.'));
     }
@@ -329,7 +300,6 @@ function djatoka_base_url_validate($element, &$form_state, $form) {
  */
 function islandora_openseadragon_admin_submit($form, &$form_state) {
   $op = $form_state['clicked_button']['#id'];
-  dpm($op);
   switch ($op) {
     case 'edit-reset':
       variable_del('islandora_openseadragon_settings');

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -266,14 +266,14 @@ function djatoka_base_url_validate($element, &$form_state, $form) {
   $jp2_image = drupal_get_path('module', 'islandora_openseadragon') . '/test/test.jp2';
   $image_url = file_create_url($jp2_image);
   $server_url = $element['#value'];
-  $dimensions = '0,0,100,100';
+  $dimension = 100;
   $request = array(
-    '?url_ver' => 'Z39.88-2004',
+    'url_ver' => 'Z39.88-2004',
     'rft_id' => $image_url,
     'svc_id' => 'info:lanl-repo/svc/getRegion',
     'svc_val_fmt' => 'info:ofi/fmt:kev:mtx:jpeg2000',
     'svc.format' => 'image/jpeg',
-    'svc.region' => $dimensions,
+    'svc.region' => "0,0,$dimension,$dimension",
     'svc.level' => '1',
   );
 
@@ -284,21 +284,21 @@ function djatoka_base_url_validate($element, &$form_state, $form) {
 
     // Work around drupal_http_request's not handling relative URLs.
     if (strpos($server_url, '/') === 0) {
-      $server_url = $GLOBALS['base_root'] . $server_url;
+      $server_url = $GLOBALS['base_root'] . ':8080' . $server_url;
     }
 
-    $full_url = $server_url . drupal_http_build_query($request);
-    $result = drupal_http_request(urldecode($full_url));
+    $full_url = $server_url . '?' . drupal_http_build_query($request);
+    $result = drupal_http_request($full_url);
     $server = FALSE;
 
     if ($result->code == 200 && $result->headers['content-type'] == 'image/jpeg') {
       $file = file_save_data($result->data, 'temporary://temp.jpg');
-      $file->status &= FILE_STATUS_PERMANENT;
+      $file->status &= ~FILE_STATUS_PERMANENT;
       $info = file_save($file);
       $info = image_get_info(drupal_realpath($file->uri));
-      $dimesnions_test = $info['width'] === 100 && $info['height'] === 100;
+      $dimensions_test = $info['width'] === $dimension && $info['height'] === $dimension;
 
-      if (isset($info['mime_type']) && $info['mime_type'] == 'image/jpeg' && $dimesnions_test) {
+      if (isset($info['mime_type']) && $info['mime_type'] == 'image/jpeg' && $dimensions_test) {
         $server = TRUE;
       }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1799
# What does this Pull Request do?

This addition will allow users to test their Djatoka server with more than just the LOC stable map JP2. Users will now have the option to provide the PID of an object with a valid JP2 datastream, or can point to a newly added test.jp2 file which lives in the modules test/ directory. When left blank, the LOC map image will be used in the test.
# How should this be tested?

After pulling down the changes, begin by running the form (/admin/islandora/islandora_viewers/openseadragon) with the new field empty, ensure no errors occur as there's no confirmation that the test was successful. If there are no issues with the LOC test move on to using the local JP2 with the supplied path in the field's description. Ensure no errors occur, and proceed to use a PID that contains a valid JP2 datastream. Play around and use different PIDs to ensure that it returns error when supplying PIDs that either don't exist or don't contain JP2 datastreams.
# Additional Notes:
- The image stored locally is a free use image.
