### PR TITLE
ISLANDORA-1959 - Update admin.form.inc with descriptive text for constrain image

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -243,6 +243,7 @@ function islandora_openseadragon_admin($form, &$form_state) {
     '#type' => 'checkbox',
     '#title' => t('Constrain image to viewport'),
     '#default_value' => variable_get('islandora_openseadragon_fit_to_aspect_ratio', FALSE),
+    '#description' => t('On the initial page load, the entire image will be visible in the viewport.'),
   );
 
   // Actions.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1959

# What does this Pull Request do?

Adds a line of descriptive text in the configuration form to clarify what "Constrain image to viewport" does (because there was some confusion over other function it might have). The new text reads: "On the initial page load, the entire image will be visible in the viewport."

# What's new?
One new line of descriptive text  on a checkbox in a form.

# How should this be tested?

Go to the Openseadragon configuration page and look for the last checkbox. Instead of just a checkbox and "Constrain image to viewport", you should see:

![image](https://cloud.githubusercontent.com/assets/2371345/24558775/bd66cfaa-1612-11e7-9c75-0bb74e2012ee.png)


# Additional Notes:
Another PR for 7.x-1.9 will be along shortly.

* Does this change require documentation to be updated? 
This change _is_ documentation.
 
# Interested parties
@whikloj (componant manager) @DonRichards (docs manager) or @DiegoPino (release manager)
