### PR TITLE
ISLANDORA-2053: Update travis.yml to force PHP 5.3 to run under Ubuntu Precise 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,40 @@
 sudo: required
+dist: trusty
 language: php
+
+matrix:
+  include:
+   #5.3.3 Ubuntu Precise exceptions
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
-  - 5.3.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
-branches:
-  only:
-    - /^7.x/
 env:
   - FEDORA_VERSION="3.5"
   - FEDORA_VERSION="3.6.2"
   - FEDORA_VERSION="3.7.0"
   - FEDORA_VERSION="3.8.1"
+
+branches:
+  only:
+    - /^7.x/
 before_install:
   - cd $HOME
   - git clone -b 7.x git://github.com/Islandora/islandora.git
-  - wget http://openseadragon.github.io/releases/openseadragon-bin-0.9.124.zip
-  - unzip openseadragon-bin-0.9.124.zip
   - git clone -b 7.x git://github.com/Islandora/islandora_paged_content
   - export ISLANDORA_DIR=$HOME/islandora
   - $HOME/islandora/tests/scripts/travis_setup.sh
@@ -28,6 +43,7 @@ before_install:
   - ln -s $HOME/openseadragon sites/all/libraries/openseadragon
   - ln -s $HOME/islandora_paged_content sites/all/modules/islandora_paged_content
   - drush en --yes islandora_openseadragon
+  - drush openseadragon-plugin
  # Mysql might time out for long tests, increase the wait timeout.
   - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ before_install:
   - $HOME/islandora/tests/scripts/travis_setup.sh
   - cd $HOME/drupal-*
   - ln -s $TRAVIS_BUILD_DIR sites/all/modules/islandora_openseadragon
-  - ln -s $HOME/openseadragon sites/all/libraries/openseadragon
   - ln -s $HOME/islandora_paged_content sites/all/modules/islandora_paged_content
   - drush en --yes islandora_openseadragon
   - drush openseadragon-plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   - $HOME/islandora/tests/scripts/travis_setup.sh
   - cd $HOME/drupal-*
   - ln -s $TRAVIS_BUILD_DIR sites/all/modules/islandora_openseadragon
-  - ln -s $HOME/openseadragon sites/all/libraries/openseadragon
+  - ln -s $HOME/openseadragon-bin-2.2.1 sites/all/libraries/openseadragon
   - ln -s $HOME/islandora_paged_content sites/all/modules/islandora_paged_content
   - drush en --yes islandora_openseadragon
  # Mysql might time out for long tests, increase the wait timeout.

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,15 @@ branches:
 before_install:
   - cd $HOME
   - git clone -b 7.x git://github.com/Islandora/islandora.git
+  - wget https://github.com/openseadragon/openseadragon/releases/download/v2.2.1/openseadragon-bin-2.2.1.zip
+  - unzip openseadragon-bin-2.2.1.zip
   - git clone -b 7.x git://github.com/Islandora/islandora_paged_content
   - export ISLANDORA_DIR=$HOME/islandora
   - $HOME/islandora/tests/scripts/travis_setup.sh
   - cd $HOME/drupal-*
   - ln -s $TRAVIS_BUILD_DIR sites/all/modules/islandora_openseadragon
+  - ln -s $HOME/openseadragon sites/all/libraries/openseadragon
   - ln -s $HOME/islandora_paged_content sites/all/modules/islandora_paged_content
-  - drush cc drush
-  - drush openseadragon-plugin
   - drush en --yes islandora_openseadragon
  # Mysql might time out for long tests, increase the wait timeout.
   - mysql -e 'SET @@GLOBAL.wait_timeout=1200'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,9 @@ before_install:
   - cd $HOME/drupal-*
   - ln -s $TRAVIS_BUILD_DIR sites/all/modules/islandora_openseadragon
   - ln -s $HOME/islandora_paged_content sites/all/modules/islandora_paged_content
-  - drush en --yes islandora_openseadragon
+  - drush cc drush
   - drush openseadragon-plugin
+  - drush en --yes islandora_openseadragon
  # Mysql might time out for long tests, increase the wait timeout.
   - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
 script:


### PR DESCRIPTION
**ISLANDORA-2053**: (https://jira.duraspace.org/browse/ISLANDORA-2053)
http://irclogs.islandora.ca/2017-09-05.html
https://github.com/travis-ci/travis-ci/issues/2963
https://github.com/Islandora/islandora/pull/683

As of September 2017, Travis-CI has removed support for PHP 5.3 (and 5.2) for their Ubuntu Trusty Images, forcing us, in order  to keep Drupal's compatibility matrix tested, to run Travis-CI test for 5.3 on Ubuntu Precise


# What does this Pull Request do?

This pull Fixes our failing Travis-CI tests: 
Should allow PHP 5.3.3 to run under Ubuntu Precise and Higher versions under Ubuntu Trusty.
Changes the way we define which PHP versions and Fedora ones run in Travis

# What's new?

- We Moved PHP versions and Fedora ones into matrix section of the Travis YAML file. 
- Since https://github.com/Islandora/islandora_openseadragon/pull/65 we are actually enforcing openseadragon 2.2.1 JS library, but we were still using 0.9 during the tests. We don't have actual web integration tests (the ones that touch JS) but still better practice to use the supported library. 
- Using now ```drush openseadragon-plugin``` instead of wget to fetch the library.

# How should this be tested?
 Travis-CI should pass and everything single PHP/FEDORA version combination should look good and very green.

# Interested parties
@Islandora/7-x-1-x-committers