### PR TITLE
Islandora 2060

### DIFF
--- a/js/islandora_openseadragon.js
+++ b/js/islandora_openseadragon.js
@@ -26,11 +26,14 @@
         });
       }
     },
-    detach: function() {
-      $(base).removeClass('islandoraOpenSeadragonViewer-processed');
-      $(base).removeData();
-      $(base).off();
-      delete Drupal.IslandoraOpenSeadragonViewer[base];
+    detach: function(context, settings, trigger) {
+      // Only detach if triggered from within the Openseadragon viewer.
+      if($(base).find(context['selector']).length > 0) {
+        $(base).removeClass('islandoraOpenSeadragonViewer-processed');
+        $(base).removeData();
+        $(base).off();
+        delete Drupal.IslandoraOpenSeadragonViewer[base];
+      }
     }
   };
 

--- a/js/islandora_openseadragon.js
+++ b/js/islandora_openseadragon.js
@@ -26,9 +26,9 @@
         });
       }
     },
-    detach: function(context, settings, trigger) {
-      // Only detach if triggered from within the Openseadragon viewer.
-      if($(base).find(context['selector']).length > 0) {
+    detach: function(context) {
+      // Only detach if triggered by Openseadragon viewer.
+      if ($(context).is($(base))) {
         $(base).removeClass('islandoraOpenSeadragonViewer-processed');
         $(base).removeData();
         $(base).off();


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2060](https://jira.duraspace.org/browse/ISLANDORA-2060)

# What does this Pull Request do?

### The problem

When content is loaded via an ajax call on a page that has an Openseadragon viewer, the viewer replicates itself inside the `#islandora-openseadragon` div. 

The Drupal.behaviors.islandoraOpenSeadragon:detach function is being called during the ajax call, and this function is disabling but not removing the viewer. It also removes Drupal.IslandoraOpenSeadragonViewer[base]. 

After the detach event is done, a new attach event is triggered. When the attach function is called, it sees that there is no `Drupal.IslandoraOpenSeadragonViewer[base]`, so it adds a new one, thus duplicating the viewer. 

### Desired outcome 

Ajax calls within a page displaying an openseadragon viewer should not cause the viewer to be duplicated.

# What's new?

Adds a condition to the Drupal.behaviors.IslandoraOpenSeadragon.detach function which checks to see if the context of the detach event is the openseadragon viewer. If so, it goes ahead with the detach. But if not, then it does not detach.

# How should this be tested?

* To reproduce the duplication problem, on the page displaying the openseadragon viewer you would need to have a link that makes an ajax call. 
* Once that is implemented, this PR should cause the openseadragon viewer to not be duplicated.

# Additional Notes:

* The detach function would need to function in the case where a module wishes to create and delete openseadragon viewers. For example, if clicking on a search results pops the viewer up in a colorbox, then the close function for that may need to detach the viewer. *This has not been tested!*


# Interested parties
Tag @nigelbanks, @Islandora @7-x-1-x-committers
