### PR TITLE
add back the Drupal.settings.islandora_open_seadragon_viewer with vie…

### DIFF
--- a/js/islandora_openseadragon.js
+++ b/js/islandora_openseadragon.js
@@ -49,6 +49,7 @@
    */
   Drupal.IslandoraOpenSeadragonViewer = function (base, settings) {
     var viewer = new OpenSeadragon(settings.options);
+    Drupal.settings.islandora_open_seadragon_viewer = viewer;
 
     var update_clip = function(event) {
       var viewer = event.eventSource;


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-2080

# What does this Pull Request do?
This PR adds the Drupal.settings.islandora_open_seadragon_viewer back.  The viewer object gets used by islandora_web_annotations module.  

# How should this be tested?
* Get the PR
* Go to a large image
* Go to a debug console
* Verify that Drupal.settings.islandora_open_seadragon_viewer  returns and object

# Additional Notes:
This would add an additional variable to Drupal.settings.islandoraOpenSeadragon.  We can possibly add the viewer as a property to Drupal.settings.islandoraOpenSeadragon.  I've added the original variable back as there may be additional modules that may rely on it. 

# Interested parties
@whikloj 
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
