### PR TITLE
Only render the viewer if there's a source JP2.

### DIFF
--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -103,10 +103,13 @@ function islandora_openseadragon_callback(array $params = array(), AbstractObjec
     preg_match('/object\/([^\/]*)\/datastream/', $params['jp2_url'], $matches);
     $pid = isset($matches[1]) ? $matches[1] : NULL;
   }
-  $tile_sources = isset($params['jp2_url']) ?
-    array(islandora_openseadragon_identifier_tile_source($params['jp2_url'])) :
-    array();
-  return theme('islandora_openseadragon_viewer', array('pid' => $pid, 'tile_sources' => $tile_sources));
+  if (isset($params['jp2_url'])) {
+    return theme('islandora_openseadragon_viewer', array(
+      'pid' => $pid,
+      'tile_sources' => islandora_openseadragon_identifier_tile_source($params['jp2_url']),
+    ));
+  }
+  return array();
 }
 
 /**

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -103,13 +103,12 @@ function islandora_openseadragon_callback(array $params = array(), AbstractObjec
     preg_match('/object\/([^\/]*)\/datastream/', $params['jp2_url'], $matches);
     $pid = isset($matches[1]) ? $matches[1] : NULL;
   }
-  if (isset($params['jp2_url'])) {
+  if (isset($params['jp2_url']) && !empty($params['jp2_url'])) {
     return theme('islandora_openseadragon_viewer', array(
       'pid' => $pid,
       'tile_sources' => islandora_openseadragon_identifier_tile_source($params['jp2_url']),
     ));
   }
-  return array();
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/projects/ISLANDORA/issues/ISLANDORA-2077

# What does this Pull Request do?
Only renders the viewer if a JP2 is present.

# What's new?
Appears there was a regression in https://github.com/Islandora/islandora_openseadragon/pull/65 where a stub object (an object without an OBJ uploaded to it) now has a viewer rendered for it where previously it did not.

# How should this be tested?
Turn off the requirement of OBJ uploads from the Islandora configuration.
Ingest a large image.
Note that the view has an empty OpenSeadragon where before it did not.

# Interested parties
@Islandora/7-x-1-x-committers, @nigelgbanks
