### PR TITLE
Deprecate unused functions.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -328,6 +328,9 @@ function islandora_openseadragon_identifier_tile_source($identifier) {
  *   The metadata required by the users chosen implementation.
  */
 function islandora_openseadragon_datastream_tile_source(AbstractDatastream $datastream) {
+  $message = islandora_deprecated('7.x-1.10', t('Please use gearman-init instead.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
   $identifier = islandora_openseadragon_identifier_url($datastream);
   return islandora_openseadragon_identifier_tile_source($identifier);
 }
@@ -370,7 +373,6 @@ function islandora_openseadragon_iiif_tile_source($identifier) {
  *   - maxLevel: The maximum level to attempt to load.
  */
 function islandora_openseadragon_djatoka_tile_source($identifier) {
-  module_load_include('inc', 'islandora', 'includes/authtokens');
   return array(
     'identifier' => $identifier,
     'width' => NULL,
@@ -392,6 +394,9 @@ function islandora_openseadragon_djatoka_tile_source($identifier) {
  *   The URL at which an image server can access the given image datastream.
  */
 function islandora_openseadragon_identifier_url(AbstractDatastream $datastream) {
+  $message = islandora_deprecated('7.x-1.10', t('Please use URL passed to viewer.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
   module_load_include('inc', 'islandora', 'includes/authtokens');
   $pid = $datastream->parent->id;
   $dsid = $datastream->id;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -328,7 +328,7 @@ function islandora_openseadragon_identifier_tile_source($identifier) {
  *   The metadata required by the users chosen implementation.
  */
 function islandora_openseadragon_datastream_tile_source(AbstractDatastream $datastream) {
-  $message = islandora_deprecated('7.x-1.10', t('Please use gearman-init instead.'));
+  $message = islandora_deprecated('7.x-1.10', t('Please use islandora_openseadragon_identifier_tile_source instead.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
 
   $identifier = islandora_openseadragon_identifier_url($datastream);


### PR DESCRIPTION
## JIRA Ticket

https://jira.duraspace.org/browse/ISLANDORA-2093

## What does this Pull Request do?

Adds deprecation warnings to unused functions in the solution pack.

## What's new?

Just adds deprecation warnings, so it shouldn't cause any errors.

## Additional Notes:

@adam-vessey the only usage of these functions I can find searching in GitHub is in https://github.com/discoverygarden/islandora_paged_tei_seadragon/pull/15 that was added recently. Since this function isn't used at all in the OpenSeadragon SP, maybe the function should just be pulled out and put into the TEI pack?

# Interested parties
@Islandora/7-x-1-x-committers