### PR TITLE
Allow templates for IIIF URLs and Token to be passed as header

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This module requires the following modules/libraries:
 * [Islandora](https://github.com/islandora/islandora)
 * [Tuque](https://github.com/islandora/tuque)
 * [OpenSeadragon](https://github.com/openseadragon/openseadragon/)
+* [Drupal Token Module](https://www.drupal.org/project/token)
 
 ## Installation
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -95,7 +95,7 @@ function islandora_openseadragon_admin(array $form, array &$form_state) {
         '#element_validate' => array('token_element_validate'),
         '#token_types' => array('islandora_openseadragon'),
       ),
-      $form['settings']['archivesspace_metadata_settings']['token_tree'] = array(
+      'islandora_openseadragon_iiif_token_tree' => array(
         '#type' => 'fieldset',
         '#title' => t('Replacement patterns'),
         '#collapsible' => TRUE,

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -82,6 +82,29 @@ function islandora_openseadragon_admin(array $form, array &$form_state) {
         '#default_value' => $iiif_url,
         '#description' => t('The location of the IIIF Image Server.'),
       ),
+      'islandora_openseadragon_iiif_token_header' => array(
+        '#type' => 'checkbox',
+        '#title' => t('Add token as header'),
+        '#default_value' => variable_get('islandora_openseadragon_iiif_token_header', FALSE),
+        '#description' => t('Instead of sending the token as a query parameter, it will be sent in the X-ISLANDORA-TOKEN header.'),
+      ),
+      'islandora_openseadragon_iiif_identifier' => array(
+        '#type' => 'textfield',
+        '#title' => t('IIIF Identifier'),
+        '#default_value' => variable_get('islandora_aspace_mods_template', ""),
+        '#element_validate' => array('token_element_validate'),
+        '#token_types' => array('islandora_openseadragon'),
+      ),
+      $form['settings']['archivesspace_metadata_settings']['token_tree'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Replacement patterns'),
+        '#collapsible' => TRUE,
+        '#collapsed' => TRUE,
+        '#description' => theme('token_tree', array(
+          'token_types' => array('islandora_openseadragon'),
+          'global_types' => FALSE,
+         )),
+      ),
     ),
     'tilesource' => array(
       '#type' => 'fieldset',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -91,7 +91,7 @@ function islandora_openseadragon_admin(array $form, array &$form_state) {
       'islandora_openseadragon_iiif_identifier' => array(
         '#type' => 'textfield',
         '#title' => t('IIIF Identifier'),
-        '#default_value' => variable_get('islandora_aspace_mods_template', ""),
+        '#default_value' => variable_get('islandora_openseadragon_iiif_identifier', '[islandora_openseadragon:url_token]'),
         '#element_validate' => array('token_element_validate'),
         '#token_types' => array('islandora_openseadragon'),
       ),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -305,8 +305,9 @@ function islandora_openseadragon_default_options() {
  *   The metadata required by the users chosen implementation.
  */
 function islandora_openseadragon_identifier_tile_source($identifier) {
-  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_identifier_tile_source instead.'));
+  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_tile_source instead.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
   switch (variable_get('islandora_openseadragon_tilesource', 'djatoka')) {
     case 'djatoka':
       return islandora_openseadragon_djatoka_tile_source($identifier);
@@ -329,7 +330,7 @@ function islandora_openseadragon_identifier_tile_source($identifier) {
  *   The metadata required by the users chosen implementation.
  */
 function islandora_openseadragon_datastream_tile_source(AbstractDatastream $datastream) {
-  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_identifier_tile_source instead.'));
+  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_tile_source instead.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
 
   $identifier = islandora_openseadragon_identifier_url($datastream);
@@ -347,7 +348,7 @@ function islandora_openseadragon_datastream_tile_source(AbstractDatastream $data
  *   FALSE otherwise.
  */
 function islandora_openseadragon_iiif_tile_source($identifier) {
-  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_identifier_tile_source instead.'));
+  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_tile_source instead.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
 
   $base_url = rtrim(variable_get('islandora_openseadragon_iiif_url', 'iiif'), '/');
@@ -377,7 +378,7 @@ function islandora_openseadragon_iiif_tile_source($identifier) {
  *   - maxLevel: The maximum level to attempt to load.
  */
 function islandora_openseadragon_djatoka_tile_source($identifier) {
-  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_identifier_tile_source instead.'));
+  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_tile_source instead.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
 
   return array(
@@ -401,7 +402,7 @@ function islandora_openseadragon_djatoka_tile_source($identifier) {
  *   The URL at which an image server can access the given image datastream.
  */
 function islandora_openseadragon_identifier_url(AbstractDatastream $datastream) {
-  $message = islandora_deprecated('7.x-1.11', t('Please use URL passed to viewer.'));
+  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_tile_source instead.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
 
   module_load_include('inc', 'islandora', 'includes/authtokens');

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -45,7 +45,6 @@ function islandora_openseadragon_get_installed_version() {
  */
 function islandora_openseadragon_construct_clip_url($params, $download = FALSE) {
   global $base_root;
-  $settings = islandora_openseadragon_get_settings();
   $decoded_params = drupal_get_query_array($params);
   if (islandora_openseadragon_use_djatoka_server()) {
     $djatoka_url = url(variable_get('islandora_openseadragon_djatoka_url', 'adore-djatoka/resolver'),
@@ -306,6 +305,8 @@ function islandora_openseadragon_default_options() {
  *   The metadata required by the users chosen implementation.
  */
 function islandora_openseadragon_identifier_tile_source($identifier) {
+  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_identifier_tile_source instead.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
   switch (variable_get('islandora_openseadragon_tilesource', 'djatoka')) {
     case 'djatoka':
       return islandora_openseadragon_djatoka_tile_source($identifier);
@@ -328,7 +329,7 @@ function islandora_openseadragon_identifier_tile_source($identifier) {
  *   The metadata required by the users chosen implementation.
  */
 function islandora_openseadragon_datastream_tile_source(AbstractDatastream $datastream) {
-  $message = islandora_deprecated('7.x-1.10', t('Please use gearman-init instead.'));
+  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_identifier_tile_source instead.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
 
   $identifier = islandora_openseadragon_identifier_url($datastream);
@@ -346,6 +347,9 @@ function islandora_openseadragon_datastream_tile_source(AbstractDatastream $data
  *   FALSE otherwise.
  */
 function islandora_openseadragon_iiif_tile_source($identifier) {
+  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_identifier_tile_source instead.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
   $base_url = rtrim(variable_get('islandora_openseadragon_iiif_url', 'iiif'), '/');
   $identifier = urlencode($identifier);
   return file_create_url("$base_url/$identifier");
@@ -373,6 +377,9 @@ function islandora_openseadragon_iiif_tile_source($identifier) {
  *   - maxLevel: The maximum level to attempt to load.
  */
 function islandora_openseadragon_djatoka_tile_source($identifier) {
+  $message = islandora_deprecated('7.x-1.11', t('Please use islandora_openseadragon_identifier_tile_source instead.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
   return array(
     'identifier' => $identifier,
     'width' => NULL,
@@ -394,7 +401,7 @@ function islandora_openseadragon_djatoka_tile_source($identifier) {
  *   The URL at which an image server can access the given image datastream.
  */
 function islandora_openseadragon_identifier_url(AbstractDatastream $datastream) {
-  $message = islandora_deprecated('7.x-1.10', t('Please use URL passed to viewer.'));
+  $message = islandora_deprecated('7.x-1.11', t('Please use URL passed to viewer.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
 
   module_load_include('inc', 'islandora', 'includes/authtokens');
@@ -411,6 +418,117 @@ function islandora_openseadragon_identifier_url(AbstractDatastream $datastream) 
       'https' => FALSE,
     )
   );
+}
+
+/**
+ * Gets a array formated for the token_replace function.
+ *
+ * @param string $pid
+ *   PID of the object.
+ * @param string $dsid
+ *   DSID of the object.
+ * @param string $token
+ *   Token for the object.
+ *
+ * @return array
+ *   Data to be passed to token_replace.
+ */
+function islandora_openseadragon_create_replacement_array($pid, $dsid, $token) {
+  return array(
+    'islandora_openseadragon' => array(
+      'pid' => $pid,
+      'dsid' => $dsid,
+      'token' => $token,
+    )
+  );
+}
+
+/**
+ * Image metadata pertinent to the IIIF URL specification.
+ *
+ * @param string $pid
+ *   PID of the object.
+ * @param string $dsid
+ *   DSID of the object.
+ * @param string $token
+ *   Token for the object.
+ *
+ * @return string|bool
+ *   The IIIF URL to the image source if the URL can be successfully created,
+ *   FALSE otherwise.
+ */
+function islandora_openseadragon_iiif_pid_tile_source($pid, $dsid, $token) {
+  $identifier_tokens = variable_get('islandora_openseadragon_iiif_identifier', '[islandora_openseadragon:url_token]');
+  $identifier = token_replace($identifier_tokens, islandora_openseadragon_create_replacement_array($pid, $dsid, $token));
+  $base_url = rtrim(variable_get('islandora_openseadragon_iiif_url', 'iiif'), '/');
+  $identifier_encoded = urlencode($identifier);
+  return file_create_url("$base_url/$identifier_encoded");
+}
+
+/**
+ * Image metadata pertinent to the Djatoka TileSources implementation.
+ *
+ * @param string $pid
+ *   PID of the object.
+ * @param string $dsid
+ *   DSID of the object.
+ * @param string $token
+ *   Token for the object.
+ *
+ * @return array
+ *   An associative array with the required metadata for AdoraDjatoka tile
+ *   source to be rendered.
+ *   - identifier: A URL where the datastream image can be accessed.
+ *   - width: The width of the image in pixels if known.
+ *   - height: The height of the image in pixels if known.
+ *   - tileWidth: The width of the tiles to assumed to make up each pyramid
+ *     layer in pixels.
+ *   - tileHeight: The height of the tiles to assumed to make up each pyramid
+ *     layer in pixels.
+ *   - tileOverlap: The number of pixels each tile is expected to overlap
+ *     touching tiles.
+ *   - minLevel: The minimum level to attempt to load.
+ *   - maxLevel: The maximum level to attempt to load.
+ */
+function islandora_openseadragon_djatoka_pid_tile_source($pid, $dsid, $token)
+{
+  $identifier = token_replace('[islandora_openseadragon:url_token]', islandora_openseadragon_create_replacement_array($pid, $dsid, $token));
+
+  return array(
+    'identifier' => $identifier,
+    'width' => NULL,
+    'height' => NULL,
+    'tileSize' => variable_get('islandora_openseadragon_tile_size', ISLANDORA_OPENSEADRAGON_DEFAULT_TILE_SIZE),
+    'tileOverlap' => variable_get('islandora_openseadragon_tile_overlap', ISLANDORA_OPENSEADRAGON_DEFAULT_TILE_OVERLAP),
+    'minLevel' => NULL,
+    'maxLevel' => NULL,
+  );
+}
+
+/**
+ * Image metadata pertinent to the users chosen TileSources implementation.
+ *
+ * @param string $pid
+ *   PID of the object.
+ * @param string $dsid
+ *   DSID of the object.
+ * @param string $token
+ *   Token for the object.
+ *
+ * @return mixed
+ *   The metadata required by the users chosen implementation.
+ */
+function islandora_openseadragon_tile_source($pid, $dsid, $token) {
+  switch (variable_get('islandora_openseadragon_tilesource', 'djatoka')) {
+    case 'djatoka':
+      return islandora_openseadragon_djatoka_pid_tile_source($pid, $dsid, $token);
+
+    case 'iiif':
+      return islandora_openseadragon_iiif_pid_tile_source($pid, $dsid, $token);
+
+    default;
+      return array();
+  }
 }
 
 /**

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -328,6 +328,9 @@ function islandora_openseadragon_identifier_tile_source($identifier) {
  *   The metadata required by the users chosen implementation.
  */
 function islandora_openseadragon_datastream_tile_source(AbstractDatastream $datastream) {
+  $message = islandora_deprecated('7.x-1.10', t('Please use gearman-init instead.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
   $identifier = islandora_openseadragon_identifier_url($datastream);
   return islandora_openseadragon_identifier_tile_source($identifier);
 }
@@ -370,7 +373,6 @@ function islandora_openseadragon_iiif_tile_source($identifier) {
  *   - maxLevel: The maximum level to attempt to load.
  */
 function islandora_openseadragon_djatoka_tile_source($identifier) {
-  module_load_include('inc', 'islandora', 'includes/authtokens');
   return array(
     'identifier' => $identifier,
     'width' => NULL,
@@ -392,6 +394,9 @@ function islandora_openseadragon_djatoka_tile_source($identifier) {
  *   The URL at which an image server can access the given image datastream.
  */
 function islandora_openseadragon_identifier_url(AbstractDatastream $datastream) {
+  $message = islandora_deprecated('7.x-1.10', t('Please use URL passed to viewer.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
   module_load_include('inc', 'islandora', 'includes/authtokens');
   $pid = $datastream->parent->id;
   $dsid = $datastream->id;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -463,7 +463,7 @@ function islandora_openseadragon_iiif_pid_tile_source($pid, $dsid, $token) {
   $identifier = token_replace($identifier_tokens, islandora_openseadragon_create_replacement_array($pid, $dsid, $token));
   $base_url = rtrim(variable_get('islandora_openseadragon_iiif_url', 'iiif'), '/');
   $identifier_encoded = urlencode($identifier);
-  return file_create_url("$base_url/$identifier_encoded");
+  return file_create_url("$base_url/$identifier_encoded/info.json");
 }
 
 /**

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -440,7 +440,7 @@ function islandora_openseadragon_create_replacement_array($pid, $dsid, $token) {
       'pid' => $pid,
       'dsid' => $dsid,
       'token' => $token,
-    )
+    ),
   );
 }
 
@@ -491,8 +491,7 @@ function islandora_openseadragon_iiif_pid_tile_source($pid, $dsid, $token) {
  *   - minLevel: The minimum level to attempt to load.
  *   - maxLevel: The maximum level to attempt to load.
  */
-function islandora_openseadragon_djatoka_pid_tile_source($pid, $dsid, $token)
-{
+function islandora_openseadragon_djatoka_pid_tile_source($pid, $dsid, $token) {
   $identifier = token_replace('[islandora_openseadragon:url_token]', islandora_openseadragon_create_replacement_array($pid, $dsid, $token));
 
   return array(

--- a/islandora_openseadragon.info
+++ b/islandora_openseadragon.info
@@ -2,6 +2,7 @@ name = Islandora OpenSeadragon
 description = "OpenSeadragon viewer with option to serve images using djatoka"
 dependencies[] = libraries
 dependencies[] = islandora
+dependencies[] = token
 package = Islandora Viewers
 version = 7.x-dev
 core = 7.x

--- a/islandora_openseadragon.install
+++ b/islandora_openseadragon.install
@@ -54,7 +54,8 @@ function islandora_openseadragon_uninstall() {
     'islandora_openseadragon_tilesource',
     'islandora_openseadragon_djatoka_url',
     'islandora_openseadragon_iiif_url',
-
+    'islandora_openseadragon_iiif_token_header',
+    'islandora_openseadragon_iiif_identifier',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -213,7 +213,7 @@ function islandora_openseadragon_tokens($type, $tokens, array $data = array(), a
   $dsid = $data['islandora_openseadragon']['dsid'];
   $token = $data['islandora_openseadragon']['token'];
 
-  foreach($tokens as $name => $original) {
+  foreach ($tokens as $name => $original) {
     if ($name == 'pid') {
       $replacements[$original] = $pid;
     }

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -99,7 +99,7 @@ function islandora_openseadragon_islandora_viewer_info() {
 function islandora_openseadragon_callback(array $params = array(), AbstractObject $object = NULL) {
   module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');
 
-  if (isset($params['jp2_url']) && $params['jp2_url'] != NULL) {
+  if (isset($params['jp2_url']) && !(isset($params['pid']) && isset($params['dsid']) && isset($params['token']))) {
     $message = islandora_deprecated('7.x-1.11', t('The jp2_url parameter has been depreciated. Please update your code before the next release.'));
     trigger_error(filter_xss($message), E_USER_DEPRECATED);
 

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -135,3 +135,43 @@ function islandora_openseadragon_preprocess_islandora_object_print(array &$varia
     }
   }
 }
+
+/**
+ * Implements hook_token_info().
+ */
+function islandora_openseadragon_aspace_token_info() {
+  $info = array();
+
+  $info['types']['islandora_openseadragon'] = array(
+    'name' => t('Islandora Openseadragon'),
+    'description' => t('Tokens for building IIIF identifer in Islandora Openseadragon.'),
+    'needs-data' => 'islandora_openseadragon',
+  );
+
+  $info['tokens']['islandora_openseadragon']['pid'] = array(
+    'name' => t('PID'),
+    'description' => t('The objects PID.'),
+  );
+
+  $info['tokens']['islandora_openseadragon']['dsid'] = array(
+    'name' => t('DSID'),
+    'description' => t('The objects DSID.'),
+  );
+
+  $info['tokens']['islandora_openseadragon']['url'] = array(
+    'name' => t('URL'),
+    'description' => t('The URL to the object in Islandora.'),
+  );
+
+  $info['tokens']['islandora_openseadragon']['url_token'] = array(
+    'name' => t('URL with Token'),
+    'description' => t('The URL to the object in Islandora with token in the query string.'),
+  );
+
+  $info['tokens']['islandora_openseadragon']['token'] = array(
+    'name' => t('Token'),
+    'description' => t('The token that can be used to access the object in Islandora.'),
+  );
+
+  return $info;
+}

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -111,13 +111,13 @@ function islandora_openseadragon_callback(array $params = array(), AbstractObjec
     $token = isset($matches[3]) ? $matches[3] : NULL;
 
     if (!isset($params['pid'])) {
-      $params['pid'] = $pid;
+      $params['pid'] = urldecode($pid);
     }
     if (!isset($params['dsid'])) {
-      $params['dsid'] = $dsid;
+      $params['dsid'] = urldecode($dsid);
     }
     if (!isset($params['token'])) {
-      $params['token'] = $token;
+      $params['token'] = urldecode($token);
     }
   }
 

--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -87,7 +87,9 @@ function islandora_openseadragon_islandora_viewer_info() {
  *
  * @param array $params
  *   Params required by the theme. We require the keys:
- *   - jp2_url: The URL to the JP2 image.
+ *   - pid: The PID of the object.
+ *   - dsid: This DSID being displayed.
+ *   - token: The token we are working with.
  * @param AbstractObject $object
  *   The object that we are viewing.
  *
@@ -96,17 +98,38 @@ function islandora_openseadragon_islandora_viewer_info() {
  */
 function islandora_openseadragon_callback(array $params = array(), AbstractObject $object = NULL) {
   module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');
-  $pid = isset($object->id) ? $object->id : NULL;
-  if ($pid == NULL && isset($params['jp2_url'])) {
-    // Attempt to extract it from the 'jp2_url' if the object is not provided.
+
+  if (isset($params['jp2_url']) && $params['jp2_url'] != NULL) {
+    $message = islandora_deprecated('7.x-1.11', t('The jp2_url parameter has been depreciated. Please update your code before the next release.'));
+    trigger_error(filter_xss($message), E_USER_DEPRECATED);
+
+    // Try to mangle the jp2_url into the data we need.
     $matches = array();
-    preg_match('/object\/([^\/]*)\/datastream/', $params['jp2_url'], $matches);
+    preg_match('/object\/([^\/]*)\/datastream\/([^\/]*).*token=([^&]*)/', $params['jp2_url'], $matches);
     $pid = isset($matches[1]) ? $matches[1] : NULL;
+    $dsid = isset($matches[2]) ? $matches[2] : NULL;
+    $token = isset($matches[3]) ? $matches[3] : NULL;
+
+    if (!isset($params['pid'])) {
+      $params['pid'] = $pid;
+    }
+    if (!isset($params['dsid'])) {
+      $params['dsid'] = $dsid;
+    }
+    if (!isset($params['token'])) {
+      $params['token'] = $token;
+    }
   }
-  if (isset($params['jp2_url']) && !empty($params['jp2_url'])) {
+
+  if (isset($params['pid']) && isset($params['dsid']) && isset($params['token'])) {
+    $token_header = variable_get('islandora_openseadragon_tilesource', 'djatoka') == 'iiif'
+      && variable_get('islandora_openseadragon_iiif_token_header', FALSE);
+
     return theme('islandora_openseadragon_viewer', array(
-      'pid' => $pid,
-      'tile_sources' => islandora_openseadragon_identifier_tile_source($params['jp2_url']),
+      'pid' => $params['pid'],
+      'tile_sources' => islandora_openseadragon_tile_source($params['pid'], $params['dsid'], $params['token']),
+      'token' => $params['token'],
+      'token_header' => $token_header,
     ));
   }
 }
@@ -139,7 +162,7 @@ function islandora_openseadragon_preprocess_islandora_object_print(array &$varia
 /**
  * Implements hook_token_info().
  */
-function islandora_openseadragon_aspace_token_info() {
+function islandora_openseadragon_token_info() {
   $info = array();
 
   $info['types']['islandora_openseadragon'] = array(
@@ -174,4 +197,48 @@ function islandora_openseadragon_aspace_token_info() {
   );
 
   return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function islandora_openseadragon_tokens($type, $tokens, array $data = array(), array $options = array()) {
+  $replacements = array();
+
+  if ($type != 'islandora_openseadragon' || !isset($data['islandora_openseadragon'])) {
+    return $replacements;
+  }
+
+  $pid = $data['islandora_openseadragon']['pid'];
+  $dsid = $data['islandora_openseadragon']['dsid'];
+  $token = $data['islandora_openseadragon']['token'];
+
+  foreach($tokens as $name => $original) {
+    if ($name == 'pid') {
+      $replacements[$original] = $pid;
+    }
+    elseif ($name == 'dsid') {
+      $replacements[$original] = $dsid;
+    }
+    elseif ($name == 'token') {
+      $replacements[$original] = $token;
+    }
+    elseif ($name == 'url' || $name == 'url_token') {
+      $options = array(
+        'absolute' => TRUE,
+        'language' => language_default(),
+        'https' => FALSE,
+      );
+
+      if ($name == 'url_token') {
+        $options['query'] = array(
+          'token' => $token,
+        );
+      }
+
+      $replacements[$original] = url("islandora/object/{$pid}/datastream/{$dsid}/view", $options);
+    }
+  }
+
+  return $replacements;
 }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -42,7 +42,7 @@ function template_preprocess_islandora_openseadragon_viewer(array &$variables) {
     ) + islandora_openseadragon_get_settings(),
   );
   if (isset($variables['token_header']) && isset($variables['token']) && $variables['token_header']) {
-    $variables['settings']['options']['loadTilesWithAjax'] = true;
+    $variables['settings']['options']['loadTilesWithAjax'] = TRUE;
     $variables['settings']['options']['ajaxHeaders'] = array(
       'X-ISLANDORA-TOKEN' => $variables['token'],
     );

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -41,6 +41,12 @@ function template_preprocess_islandora_openseadragon_viewer(array &$variables) {
       'overlays' => islandora_openseadragon_viewer_query_solr_for_overlays($variables['pid']),
     ) + islandora_openseadragon_get_settings(),
   );
+  if (isset($variables['token_header']) && isset($variables['token']) && $variables['token_header']) {
+    $variables['settings']['options']['loadTilesWithAjax'] = true;
+    $variables['settings']['options']['ajaxHeaders'] = array(
+      'X-ISLANDORA-TOKEN' => $variables['token'],
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## JIRA Ticket

https://jira.duraspace.org/browse/ISLANDORA-2097

Blocked by: 
https://github.com/Islandora/islandora_openseadragon/pull/89

## What does this Pull Request do?

Allows more configuration on IIIF URLs, so that:
1) The identifier is configurable .
2) The token can be sent as a header.

## What's new?

There are several changes in this PR:
* The viewer now expects an array with three entries: `pid`, `dsid` and `token` instead of the only `jp2_url` string. There is code there for the deprecation period that uses a regex to pull these items out of the `jp2_url` string until people calling the viewer update. PR are forthcoming for relevant modules that call this viewer.
* Deprecates a number of functions that took 'jp2_url' as the identifier and replaces them with functions that can take the new parameters.
* Add a new dependancy for this module on the `token` module for templating.
* Adds configuration to allow IIIF users to configure the identifier.
* Adds configuration to allow IIIF users to send the token in the header.

Folks using djatoka shouldn't see any difference with this PR.

## How should this be tested?

* Make sure that images using the djatoka tile source continue to load as before.
* Test that when using IIIF
  * Setting an identifier changes the identifier that openseadragon requests
  * Setting the header feature the header is correctly sent to the IIIF server

### Browser Inspector

The IIIF tests can be accomplished by using the browser inspector to look at the network requests if no IIIF server is available. You should be able to see the requests going out to the proper URLs with the proper templating and headers. The header will not be sent to the IIIF server until https://github.com/Islandora/islandora_openseadragon/pull/89 is merged.

### Cantaloupe 🍈

#### Setup

Install a copy of the [Cantaloupe](https://medusa-project.github.io/cantaloupe/) image server. The manual there is good for configuration. 

Go through the whole cantaloupe.properties and make sure the configuration is correct, but make sure these keys are set:
```properties
delegate_script.enabled = true  # examples for delegate script are below
resolver.static = HttpResolver # we want to pull our tiles from a http source (islandora)
HttpResolver.lookup_strategy = ScriptLookupStrategy # use our delegate script to look up urls
cache.server.source.enabled = true # needs to be set to use jp2s with Kakadu or OpenJpeg processor
```

Copy the example `delegates.rb` file and use that as a starting point with the code snippets below.

Setup the authorization delegate to print the token to the logs:
```ruby
def self.authorized?(identifier, full_size, operations, resulting_size, output_format, request_uri, request_headers, client_ip, cookies)
  require 'java'
  logger = Java::edu.illinois.library.cantaloupe.script.Logger
  if request_headers.key?('X-ISLANDORA-TOKEN')
    logger.info("Token: #{request_headers['X-ISLANDORA-TOKEN']}")
  else
    logger.info("No Token Sent")
  end
  true
end
```

Setup the HttpResolver.get_url delegate to handle the identifier format you use:
```ruby
module HttpResolver
  def self.get_url(identifier)
    logger = Java::edu.illinois.library.cantaloupe.script.Logger
    values = CGI::unescape(identifier).split('~')
    if values.length != 2
      logger.debug('Returning NIL because there are not enough arguements.')
      return nil
    end
    pid = values[0]
    dsid = values[1]
    logger.info("PID: #{pid}. DSID: #{dsid}")
    return "http://my.islandora/islandora/object/#{pid}/datastream/#{dsid}/view"
  end
end
```

You can just run it on the command line for testing: 
```
java -classpath -Dcantaloupe.config=/path/to/cantaloupe.properties -Xmx500m -jar Cantaloupe-3.4-SNAPSHOT.war
``` 

Point the IIIF URL at Cantaloupe: `http://10.0.0.2:8182/iiif/2/`
Setup the IIIF identifier as: `[islandora_openseadragon:pid]~[islandora_openseadragon:dsid]`

#### Testing

You should be able to see your Islandora content in Cantaloupe now using an identifier of the form: `pid~dsid`.

- Test that you can see large images served by cantaloupe
- Check the cantaloupe logs to see the PID and DSID printed there
- Try enabling the token in the header, you should be able to see the token in the cantaloupe logs

Note: If you are accessing the site via https cantaloupe needs to be running with HTTPs.

## Additional Notes:

* Does this change add any new dependencies? 
  * Yes it adds a new dependancy on `token`
* Could this change impact execution of existing code?
  * Yes it changes the parameters expected by the viewer, but it has a deprecation notice, and a function that will make it work.

## Interested parties

@whikloj 