### PR TITLE
Use the scheme of the request.

### DIFF
--- a/islandora_openseadragon.module
+++ b/islandora_openseadragon.module
@@ -227,7 +227,7 @@ function islandora_openseadragon_tokens($type, $tokens, array $data = array(), a
       $options = array(
         'absolute' => TRUE,
         'language' => language_default(),
-        'https' => FALSE,
+        'https' => drupal_is_https(),
       );
 
       if ($name == 'url_token') {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2161

# What does this Pull Request do?

When generating the url of the tile_source [here](https://github.com/Islandora/islandora_openseadragon/blob/7.x/islandora_openseadragon.module#L239) ensure that if the request is SSL then make the url token built with SSL. Instead of a hard-coded `FALSE` we call [`drupal_is_http()`](https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_is_https/7.x) [here](https://github.com/Islandora/islandora_openseadragon/blob/7.x/islandora_openseadragon.module#L230)

# What's new?

# How should this be tested?

I am guessing if your server supports both HTTP and HTTPS this does not appear as an issue. It is also possible that this is only when using the IIIF source. I am using Cantaloupe.

When I was loading the page `https://jujo.ad.umanitoba.ca/islandora/object/uofm%3A1243056` in Firefox the console displayed.

```
AJAX request returned 403: /cantaloupe/iiif/2/http%3A%2F%2Fjujo.ad.umanitoba.ca%2Fislandora%2Fobject%2Fuofm%253A1243056%2Fdatastream%2FJP2%2Fview%3Ftoken%3D7d3c2f0cd81875b863649b799b2d765a51f45df46ab0a6fcebf3c9385679d5b0/info.json
```

before this change. After there is no message and the image is displayed in OpenSeadragon.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? possibly

# Interested parties
@jonathangreen @DiegoPino 
