### PR TITLE
Sanitize clipper's Download Image filename for HTTP header

### DIFF
--- a/includes/download.clip.inc
+++ b/includes/download.clip.inc
@@ -16,7 +16,13 @@ function islandora_openseadragon_download_clip(AbstractObject $object) {
     module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');
     $clip_parts = islandora_openseadragon_construct_clip_url($_GET['clip'], TRUE);
     if ($clip_parts) {
-      $filename = $object->label;
+      $regex = '/\'|\"|@|,|%|\+|\{|\}|\[|\]|#|&|=|\.|\$/';
+      $space_regex = '/\s/';
+      $filename = strtolower($object->label);
+      if (preg_match($regex, $filename)) {
+        $escaped = preg_replace($regex, '', $filename);
+        $filename = preg_replace($space_regex, '_', $escaped);
+      }
       header("Content-Disposition: attachment; filename=\"{$filename}.jpg\"");
       header("Content-type: image/jpeg");
       header("Content-Transfer-Encoding: binary");

--- a/includes/download.clip.inc
+++ b/includes/download.clip.inc
@@ -16,13 +16,12 @@ function islandora_openseadragon_download_clip(AbstractObject $object) {
     module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');
     $clip_parts = islandora_openseadragon_construct_clip_url($_GET['clip'], TRUE);
     if ($clip_parts) {
-      $regex = '/[^a-zA-z0-9\s]/';
-      $space = '/\s/';
       $filename = strtolower($object->label);
-      if (preg_match($regex, $filename) || preg_match($space, $filename)) {
-        $escaped = preg_replace($regex, '', $filename);
-        $filename = preg_replace($space, '_', $escaped);
-      }
+      $map = array(
+        '/\s/' => '_',
+        "/[^0-9A-Za-z_]/" => '',
+      );
+      $filename = trim(preg_replace(array_keys($map), array_values($map), $filename));
       header("Content-Disposition: attachment; filename=\"{$filename}.jpg\"");
       header("Content-type: image/jpeg");
       header("Content-Transfer-Encoding: binary");

--- a/includes/download.clip.inc
+++ b/includes/download.clip.inc
@@ -16,12 +16,12 @@ function islandora_openseadragon_download_clip(AbstractObject $object) {
     module_load_include('inc', 'islandora_openseadragon', 'includes/utilities');
     $clip_parts = islandora_openseadragon_construct_clip_url($_GET['clip'], TRUE);
     if ($clip_parts) {
-      $regex = '/\'|\"|@|,|%|\+|\{|\}|\[|\]|#|&|=|\.|\$/';
-      $space_regex = '/\s/';
+      $regex = '/[^a-zA-z0-9\s]/';
+      $space = '/\s/';
       $filename = strtolower($object->label);
-      if (preg_match($regex, $filename)) {
+      if (preg_match($regex, $filename) || preg_match($space, $filename)) {
         $escaped = preg_replace($regex, '', $filename);
-        $filename = preg_replace($space_regex, '_', $escaped);
+        $filename = preg_replace($space, '_', $escaped);
       }
       header("Content-Disposition: attachment; filename=\"{$filename}.jpg\"");
       header("Content-type: image/jpeg");

--- a/includes/download.clip.inc
+++ b/includes/download.clip.inc
@@ -19,9 +19,12 @@ function islandora_openseadragon_download_clip(AbstractObject $object) {
       $filename = strtolower($object->label);
       $map = array(
         '/\s/' => '_',
-        "/[^0-9A-Za-z_]/" => '',
+        '/[\'\",\.\?\:\;\(\)\&\!]/' => '',
       );
       $filename = trim(preg_replace(array_keys($map), array_values($map), $filename));
+      if (strlen($filename) <= 0 || (strlen($filename) <= substr_count($filename, '_'))) {
+        $filename = 'download_clip_' . date('Ymd');
+      }
       header("Content-Disposition: attachment; filename=\"{$filename}.jpg\"");
       header("Content-type: image/jpeg");
       header("Content-Transfer-Encoding: binary");


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2476)

# What does this Pull Request do?
Applies a standard formatting to an object's label before use as a filename. Primarily removing characters that are not a part of ISO-8859-1 character set (such as quotes and commas) and replacing spaces with underscores. Reference: https://tools.ietf.org/html/rfc5987

# How should this be tested?
<---- Before merging code ---->
Using image clipper's "Download Image" link, download an image with quotes and/or commas in the name. The file name will be truncated. This has been confirmed in Firefox and Safari. Chrome appears to apply some encoding (replacing the characters with underscores).
<---- After merging code ---->
Using image clipper's "Download Image" link, download an image with quotes and/or commas in the name. Illegal characters such as quotes and commas should be stripped and spaces replaced with underscores.

NOTE this should be tested in various browsers as well (Safari, Chrome, etc.)

# Additional Notes:
* PHP's strtolower is also applied.
* header("Content-Disposition: attachment; filename*=us-ascii'{$filename}.jpg"); was not used as I found labels such as "The quick brown fox" would become _The quick brown fox_.jpg which did not seem like an acceptable filename.
* Reference is made to the transliteration module (https://www.drupal.org/project/transliteration) and Drupal 8's file_munge_filename function (https://api.drupal.org/api/drupal/core%21includes%21file.inc/function/file_munge_filename/8.2.x)

Example:
* Object name "'The Lion,' Wyandotte Ravine" would yield the_lion_wyandotte_ravine.jpg

# Interested parties
@Islandora/7-x-1-x-committers
@DiegoPino 